### PR TITLE
Make CPU idleness profiling as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ For official benchmarking:
 1. `SIZE` environmental variable: the size should be **at least 25 times the read/write bandwidth** to avoid the caching impacting the result.
 1. If you're testing a distributed storage solution like Longhorn, always **test against the local storage first** to know what's the baseline.
     * You can install a storage provider for local storage like [Local Path Provisioner](https://github.com/rancher/local-path-provisioner) for this test if you're testing with Kubernetes.
+1. `CPU_IDLE_PROF` environmental variable: the CPU idleness profiling measures the CPU idleness, but it introduces extra overhead and reduces the storage performance. By default, the flag is disabled.
 
 ### Understanding the result
 * **IOPS**: IO operations per second. *Higher is better.*

--- a/deploy/fio-cmp.yaml
+++ b/deploy/fio-cmp.yaml
@@ -55,6 +55,8 @@ spec:
           value: "/volume2/test"
         - name: SIZE
           value: "30G" # must be smaller or match the PVC size
+        - name: CPU_IDLE_PROF
+          value: "disabled" # must be "enabled" or "disabled"
         volumeMounts:
         - name: vol1
           mountPath: /volume1/

--- a/deploy/fio.yaml
+++ b/deploy/fio.yaml
@@ -34,6 +34,8 @@ spec:
           value: "/volume/test"
         - name: SIZE
           value: "30G" # must be 10% smaller than the PVC size due to filesystem also took space
+        - name: CPU_IDLE_PROF
+          value: "disabled" # must be "enabled" or "disabled"
         volumeMounts:
         - name: vol
           mountPath: /volume/

--- a/fio/cmp_parse.sh
+++ b/fio/cmp_parse.sh
@@ -73,20 +73,21 @@ calc_cmp_lat
 
 RESULT=${FIRST_VOL_NAME}_vs_${SECOND_VOL_NAME}.summary
 
-QUICK_MODE_TEXT="QUICK MODE: DISABLED"
+QUICK_MODE_TEXT="Quick Mode: disabled"
 if [ -n "$QUICK_MODE" ]; then
-	QUICK_MODE_TEXT="QUICK MODE ENABLED"
+	QUICK_MODE_TEXT="Quick Mode: enabled"
 fi
 
 SIZE_TEXT="SIZE: 10g"
 if [ -n "$SIZE" ]; then
-	SIZE_TEXT="SIZE: $SIZE"
+	SIZE_TEXT="Size: $SIZE"
 fi
 
 SUMMARY="
 ================================
 FIO Benchmark Comparsion Summary
 For: $FIRST_VOL_NAME vs $SECOND_VOL_NAME
+CPU Idleness Profiling: $CPU_IDLE_PROF
 $SIZE_TEXT
 $QUICK_MODE_TEXT
 ================================
@@ -96,68 +97,115 @@ printf -v header "$CMP_FMT" \
 	"" $FIRST_VOL_NAME "vs" $SECOND_VOL_NAME ":" "Change"
 SUMMARY+=$header
 
-printf -v cxt "IOPS (Read/Write)\n$CMP_FMT$CMP_FMT$CMP_FMT\n" \
-	"Random:" \
-        "$(commaize $FIRST_RAND_READ_IOPS) / $(commaize $FIRST_RAND_WRITE_IOPS)" \
-	"vs" \
-        "$(commaize $SECOND_RAND_READ_IOPS) / $(commaize $SECOND_RAND_WRITE_IOPS)"\
-        ":" \
-	"$CMP_RAND_READ_IOPS / $CMP_RAND_WRITE_IOPS"\
-	"Sequential:" \
-        "$(commaize $FIRST_SEQ_READ_IOPS) / $(commaize $FIRST_SEQ_WRITE_IOPS)" \
-	"vs" \
-        "$(commaize $SECOND_SEQ_READ_IOPS) / $(commaize $SECOND_SEQ_WRITE_IOPS)" \
-        ":" \
-	"$CMP_SEQ_READ_IOPS / $CMP_SEQ_WRITE_IOPS"\
-	"CPU Idleness:" \
-	"$FIRST_CPU_IDLE_PCT_IOPS%"\
-	"vs" \
-	"$SECOND_CPU_IDLE_PCT_IOPS%"\
-        ":" \
-	"$CMP_CPU_IDLE_PCT_IOPS%"
-SUMMARY+=$cxt
+if [ x"$CPU_IDLE_PROF" = x"enabled" ]; then
+	printf -v cxt "IOPS (Read/Write)\n$CMP_FMT$CMP_FMT$CMP_FMT\n" \
+		"Random:" \
+		"$(commaize $FIRST_RAND_READ_IOPS) / $(commaize $FIRST_RAND_WRITE_IOPS)" \
+		"vs" \
+		"$(commaize $SECOND_RAND_READ_IOPS) / $(commaize $SECOND_RAND_WRITE_IOPS)" \
+		":" \
+		"$CMP_RAND_READ_IOPS / $CMP_RAND_WRITE_IOPS" \
+		"Sequential:" \
+		"$(commaize $FIRST_SEQ_READ_IOPS) / $(commaize $FIRST_SEQ_WRITE_IOPS)" \
+		"vs" \
+		"$(commaize $SECOND_SEQ_READ_IOPS) / $(commaize $SECOND_SEQ_WRITE_IOPS)" \
+		":" \
+		"$CMP_SEQ_READ_IOPS / $CMP_SEQ_WRITE_IOPS" \
+		"CPU Idleness:" \
+		"$FIRST_CPU_IDLE_PCT_IOPS%" \
+		"vs" \
+		"$SECOND_CPU_IDLE_PCT_IOPS%"\
+		":" \
+		"$CMP_CPU_IDLE_PCT_IOPS%"
+	SUMMARY+=$cxt
 
-printf -v cxt "Bandwidth in KiB/sec (Read/Write)\n$CMP_FMT$CMP_FMT$CMP_FMT\n" \
-	"Random:" \
-        "$(commaize $FIRST_RAND_READ_BW) / $(commaize $FIRST_RAND_WRITE_BW)" \
-	"vs" \
-        "$(commaize $SECOND_RAND_READ_BW) / $(commaize $SECOND_RAND_WRITE_BW)" \
-        ":" \
-	"$CMP_RAND_READ_BW / $CMP_RAND_WRITE_BW"\
-	"Sequential:" \
-        "$(commaize $FIRST_SEQ_READ_BW) / $(commaize $FIRST_SEQ_WRITE_BW)" \
-	"vs" \
-        "$(commaize $SECOND_SEQ_READ_BW) / $(commaize $SECOND_SEQ_WRITE_BW)" \
-        ":" \
-	"$CMP_SEQ_READ_BW / $CMP_SEQ_WRITE_BW"\
-	"CPU Idleness:" \
-	"$FIRST_CPU_IDLE_PCT_BW%"\
-	"vs" \
-	"$SECOND_CPU_IDLE_PCT_BW%" \
-        ":" \
-	"$CMP_CPU_IDLE_PCT_BW%"
-SUMMARY+=$cxt
+	printf -v cxt "Bandwidth in KiB/sec (Read/Write)\n$CMP_FMT$CMP_FMT$CMP_FMT\n" \
+		"Random:" \
+		"$(commaize $FIRST_RAND_READ_BW) / $(commaize $FIRST_RAND_WRITE_BW)" \
+		"vs" \
+		"$(commaize $SECOND_RAND_READ_BW) / $(commaize $SECOND_RAND_WRITE_BW)" \
+		":" \
+		"$CMP_RAND_READ_BW / $CMP_RAND_WRITE_BW" \
+		"Sequential:" \
+		"$(commaize $FIRST_SEQ_READ_BW) / $(commaize $FIRST_SEQ_WRITE_BW)" \
+		"vs" \
+		"$(commaize $SECOND_SEQ_READ_BW) / $(commaize $SECOND_SEQ_WRITE_BW)" \
+		":" \
+		"$CMP_SEQ_READ_BW / $CMP_SEQ_WRITE_BW" \
+		"CPU Idleness:" \
+		"$FIRST_CPU_IDLE_PCT_BW%" \
+		"vs" \
+		"$SECOND_CPU_IDLE_PCT_BW%" \
+		":" \
+		"$CMP_CPU_IDLE_PCT_BW%"
+	SUMMARY+=$cxt
 
-printf -v cxt "Latency in ns (Read/Write)\n$CMP_FMT$CMP_FMT$CMP_FMT\n" \
-	"Random:" \
-        "$(commaize $FIRST_RAND_READ_LAT) / $(commaize $FIRST_RAND_WRITE_LAT)" \
-	"vs" \
-        "$(commaize $SECOND_RAND_READ_LAT) / $(commaize $SECOND_RAND_WRITE_LAT)" \
-        ":" \
-	"$CMP_RAND_READ_LAT / $CMP_RAND_WRITE_LAT"\
-	"Sequential:" \
-        "$(commaize $FIRST_SEQ_READ_LAT) / $(commaize $FIRST_SEQ_WRITE_LAT)" \
-	"vs" \
-        "$(commaize $SECOND_SEQ_READ_LAT) / $(commaize $SECOND_SEQ_WRITE_LAT)" \
-        ":" \
-	"$CMP_SEQ_READ_LAT / $CMP_SEQ_WRITE_LAT"\
-	"CPU Idleness:" \
-	"$FIRST_CPU_IDLE_PCT_LAT%"\
-	"vs" \
-	"$SECOND_CPU_IDLE_PCT_LAT%" \
-        ":" \
-	"$CMP_CPU_IDLE_PCT_LAT%"
-SUMMARY+=$cxt
+	printf -v cxt "Latency in ns (Read/Write)\n$CMP_FMT$CMP_FMT$CMP_FMT\n" \
+		"Random:" \
+		"$(commaize $FIRST_RAND_READ_LAT) / $(commaize $FIRST_RAND_WRITE_LAT)" \
+		"vs" \
+		"$(commaize $SECOND_RAND_READ_LAT) / $(commaize $SECOND_RAND_WRITE_LAT)" \
+		":" \
+		"$CMP_RAND_READ_LAT / $CMP_RAND_WRITE_LAT" \
+		"Sequential:" \
+		"$(commaize $FIRST_SEQ_READ_LAT) / $(commaize $FIRST_SEQ_WRITE_LAT)" \
+		"vs" \
+		"$(commaize $SECOND_SEQ_READ_LAT) / $(commaize $SECOND_SEQ_WRITE_LAT)" \
+		":" \
+		"$CMP_SEQ_READ_LAT / $CMP_SEQ_WRITE_LAT" \
+		"CPU Idleness:" \
+		"$FIRST_CPU_IDLE_PCT_LAT%" \
+		"vs" \
+		"$SECOND_CPU_IDLE_PCT_LAT%" \
+		":" \
+		"$CMP_CPU_IDLE_PCT_LAT%"
+		SUMMARY+=$cxt
+else
+	printf -v cxt "IOPS (Read/Write)\n$CMP_FMT$CMP_FMT\n" \
+		"Random:" \
+		"$(commaize $FIRST_RAND_READ_IOPS) / $(commaize $FIRST_RAND_WRITE_IOPS)" \
+		"vs" \
+		"$(commaize $SECOND_RAND_READ_IOPS) / $(commaize $SECOND_RAND_WRITE_IOPS)" \
+		":" \
+		"$CMP_RAND_READ_IOPS / $CMP_RAND_WRITE_IOPS" \
+		"Sequential:" \
+		"$(commaize $FIRST_SEQ_READ_IOPS) / $(commaize $FIRST_SEQ_WRITE_IOPS)" \
+		"vs" \
+		"$(commaize $SECOND_SEQ_READ_IOPS) / $(commaize $SECOND_SEQ_WRITE_IOPS)" \
+		":" \
+		"$CMP_SEQ_READ_IOPS / $CMP_SEQ_WRITE_IOPS"
+	SUMMARY+=$cxt
+
+	printf -v cxt "Bandwidth in KiB/sec (Read/Write)\n$CMP_FMT$CMP_FMT\n" \
+		"Random:" \
+		"$(commaize $FIRST_RAND_READ_BW) / $(commaize $FIRST_RAND_WRITE_BW)" \
+		"vs" \
+		"$(commaize $SECOND_RAND_READ_BW) / $(commaize $SECOND_RAND_WRITE_BW)" \
+		":" \
+		"$CMP_RAND_READ_BW / $CMP_RAND_WRITE_BW" \
+		"Sequential:" \
+		"$(commaize $FIRST_SEQ_READ_BW) / $(commaize $FIRST_SEQ_WRITE_BW)" \
+		"vs" \
+		"$(commaize $SECOND_SEQ_READ_BW) / $(commaize $SECOND_SEQ_WRITE_BW)" \
+		":" \
+		"$CMP_SEQ_READ_BW / $CMP_SEQ_WRITE_BW"
+	SUMMARY+=$cxt
+
+	printf -v cxt "Latency in ns (Read/Write)\n$CMP_FMT$CMP_FMT\n" \
+		"Random:" \
+		"$(commaize $FIRST_RAND_READ_LAT) / $(commaize $FIRST_RAND_WRITE_LAT)" \
+		"vs" \
+		"$(commaize $SECOND_RAND_READ_LAT) / $(commaize $SECOND_RAND_WRITE_LAT)" \
+		":" \
+		"$CMP_RAND_READ_LAT / $CMP_RAND_WRITE_LAT" \
+		"Sequential:" \
+		"$(commaize $FIRST_SEQ_READ_LAT) / $(commaize $FIRST_SEQ_WRITE_LAT)" \
+		"vs" \
+		"$(commaize $SECOND_SEQ_READ_LAT) / $(commaize $SECOND_SEQ_WRITE_LAT)" \
+		":" \
+		"$CMP_SEQ_READ_LAT / $CMP_SEQ_WRITE_LAT"
+		SUMMARY+=$cxt
+fi
 
 echo "$SUMMARY" > $RESULT
 cat $RESULT

--- a/fio/parse.sh
+++ b/fio/parse.sh
@@ -36,51 +36,75 @@ fi
 
 RESULT=${1}.summary
 
-QUICK_MODE_TEXT="QUICK MODE: DISABLED"
+QUICK_MODE_TEXT="Quick Mode: disabled"
 if [ -n "$QUICK_MODE" ]; then
-	QUICK_MODE_TEXT="QUICK MODE ENABLED"
+	QUICK_MODE_TEXT="Quick Mode: enabled"
 fi
 
-SIZE_TEXT="SIZE: 10g"
+SIZE_TEXT="Size: 10g"
 if [ -n "$SIZE" ]; then
-	SIZE_TEXT="SIZE: $SIZE"
+	SIZE_TEXT="Size: $SIZE"
 fi
 
 SUMMARY="
-=====================
+=========================
 FIO Benchmark Summary
 For: $PREFIX
+CPU Idleness Profiling: $CPU_IDLE_PROF
 $SIZE_TEXT
 $QUICK_MODE_TEXT
-=====================
+=========================
 "
 
-printf -v cxt "IOPS (Read/Write)\n$FMT$FMT$FMT\n"\
-	"Random:" \
-	"$(commaize $RAND_READ_IOPS) / $(commaize $RAND_WRITE_IOPS)" \
-	"Sequential:" \
-	"$(commaize $SEQ_READ_IOPS) / $(commaize $SEQ_WRITE_IOPS)" \
-	"CPU Idleness:" \
-	"$CPU_IDLE_PCT_IOPS%"
-SUMMARY+=$cxt
+if [ x"$CPU_IDLE_PROF" = x"enabled" ]; then
+	printf -v cxt "IOPS (Read/Write)\n$FMT$FMT$FMT\n"\
+		"Random:" \
+		"$(commaize $RAND_READ_IOPS) / $(commaize $RAND_WRITE_IOPS)" \
+		"Sequential:" \
+		"$(commaize $SEQ_READ_IOPS) / $(commaize $SEQ_WRITE_IOPS)" \
+		"CPU Idleness:" \
+		"$CPU_IDLE_PCT_IOPS%"
+	SUMMARY+=$cxt
 
-printf -v cxt "Bandwidth in KiB/sec (Read/Write)\n$FMT$FMT$FMT\n"\
-	"Random:" \
-	"$(commaize $RAND_READ_BW) / $(commaize $RAND_WRITE_BW)" \
-	"Sequential:" \
-	"$(commaize $SEQ_READ_BW) / $(commaize $SEQ_WRITE_BW)" \
-	"CPU Idleness:" \
-	"$CPU_IDLE_PCT_BW%"
-SUMMARY+=$cxt
+	printf -v cxt "Bandwidth in KiB/sec (Read/Write)\n$FMT$FMT$FMT\n"\
+		"Random:" \
+		"$(commaize $RAND_READ_BW) / $(commaize $RAND_WRITE_BW)" \
+		"Sequential:" \
+		"$(commaize $SEQ_READ_BW) / $(commaize $SEQ_WRITE_BW)" \
+		"CPU Idleness:" \
+		"$CPU_IDLE_PCT_BW%"
+	SUMMARY+=$cxt
 
-printf -v cxt "Latency in ns (Read/Write)\n$FMT$FMT$FMT\n"\
-	"Random:" \
-	"$(commaize $RAND_READ_LAT) / $(commaize $RAND_WRITE_LAT)" \
-	"Sequential:" \
-	"$(commaize $SEQ_READ_LAT) / $(commaize $SEQ_WRITE_LAT)" \
-	"CPU Idleness:" \
-	"$CPU_IDLE_PCT_LAT%"
-SUMMARY+=$cxt
+	printf -v cxt "Latency in ns (Read/Write)\n$FMT$FMT\n"\
+		"Random:" \
+		"$(commaize $RAND_READ_LAT) / $(commaize $RAND_WRITE_LAT)" \
+		"Sequential:" \
+		"$(commaize $SEQ_READ_LAT) / $(commaize $SEQ_WRITE_LAT)" \
+		"CPU Idleness:" \
+		"$CPU_IDLE_PCT_LAT%"
+	SUMMARY+=$cxt
+else
+	printf -v cxt "IOPS (Read/Write)\n$FMT$FMT\n"\
+		"Random:" \
+		"$(commaize $RAND_READ_IOPS) / $(commaize $RAND_WRITE_IOPS)" \
+		"Sequential:" \
+		"$(commaize $SEQ_READ_IOPS) / $(commaize $SEQ_WRITE_IOPS)"
+	SUMMARY+=$cxt
+
+	printf -v cxt "Bandwidth in KiB/sec (Read/Write)\n$FMT$FMT$FMT\n"\
+		"Random:" \
+		"$(commaize $RAND_READ_BW) / $(commaize $RAND_WRITE_BW)" \
+		"Sequential:" \
+		"$(commaize $SEQ_READ_BW) / $(commaize $SEQ_WRITE_BW)"
+	SUMMARY+=$cxt
+
+	printf -v cxt "Latency in ns (Read/Write)\n$FMT$FMT\n"\
+		"Random:" \
+		"$(commaize $RAND_READ_LAT) / $(commaize $RAND_WRITE_LAT)" \
+		"Sequential:" \
+		"$(commaize $SEQ_READ_LAT) / $(commaize $SEQ_WRITE_LAT)"
+	SUMMARY+=$cxt
+fi
 
 echo "$SUMMARY" > $RESULT
 cat $RESULT

--- a/fio/run.sh
+++ b/fio/run.sh
@@ -16,6 +16,10 @@ if [ -z "$TEST_FILE" ]; then
         exit 1
 fi
 
+if [ x"$CPU_IDLE_PROF" = x"enabled" ]; then
+	IDLE_PROF="--idle-prof=percpu"
+fi
+
 echo TEST_FILE: $TEST_FILE
 
 OUTPUT=$2
@@ -49,13 +53,13 @@ OUTPUT_BW=${OUTPUT}-bandwidth.json
 OUTPUT_LAT=${OUTPUT}-latency.json
 
 echo Benchmarking $IOPS_FIO into $OUTPUT_IOPS
-fio $CURRENT_DIR/$IOPS_FIO --idle-prof=percpu --filename=$TEST_FILE --size=$TEST_SIZE \
+fio $CURRENT_DIR/$IOPS_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
 	--output-format=json --output=$OUTPUT_IOPS
 echo Benchmarking $BW_FIO into $OUTPUT_BW
-fio $CURRENT_DIR/$BW_FIO --idle-prof=percpu --filename=$TEST_FILE --size=$TEST_SIZE \
+fio $CURRENT_DIR/$BW_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
 	--output-format=json --output=$OUTPUT_BW
 echo Benchmarking $LAT_FIO into $OUTPUT_LAT
-fio $CURRENT_DIR/$LAT_FIO --idle-prof=percpu --filename=$TEST_FILE --size=$TEST_SIZE \
+fio $CURRENT_DIR/$LAT_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
 	--output-format=json --output=$OUTPUT_LAT
 
 if [ -z "$SKIP_PARSE" ]; then


### PR DESCRIPTION
The CPU idleness introduces extra overhead and storage performance drop.
By default, the profiling is disabled.

Signed-off-by: Derek Su <derek.su@suse.com>