### PR TITLE
fio: add iostat and keep the output files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
-RUN apt update && apt install -y fio bash jq
+RUN apt update && apt install -y fio bash jq vim atop sysstat util-linux
 
 ADD ./fio/ /fio/
-WORKDIR ["/fio/"]
+WORKDIR /fio
 ENTRYPOINT ["bash", "/fio/run.sh"]

--- a/deploy/fio-cmp.yaml
+++ b/deploy/fio-cmp.yaml
@@ -49,15 +49,21 @@ spec:
           value: Local-Path
         - name: FIRST_VOL_FILE
           value: "/volume1/test"
+        - name: FIRST_VOL_BACKEND_DEVICE
+          value: "" # the backend device of first volume
         - name: SECOND_VOL_NAME
           value: Longhorn
         - name: SECOND_VOL_FILE
           value: "/volume2/test"
+        - name: SECOND_VOL_BACKEND_DEVICE
+          value: "" # the backend device of second volume
         - name: SIZE
           value: "30G" # must be smaller or match the PVC size
         - name: CPU_IDLE_PROF
           value: "disabled" # must be "enabled" or "disabled"
         volumeMounts:
+        - name: output
+          mountPath: output/
         - name: vol1
           mountPath: /volume1/
         - name: vol2
@@ -68,8 +74,14 @@ spec:
         #  devicePath: /volume1/test
         #- name: vol2
         #  devicePath: /volume2/test
+        securityContext:
+          privileged: true
       restartPolicy: Never
       volumes:
+      - name: output
+        hostPath:
+          path: /root/output # replace with your host path for output
+          type: DirectoryOrCreate
       - name: vol1
         persistentVolumeClaim:
           claimName: kbench-pvc-1

--- a/deploy/fio.yaml
+++ b/deploy/fio.yaml
@@ -30,6 +30,8 @@ spec:
         env:
         #- name: QUICK_MODE  # for debugging
         #  value: "1"
+        - name: LONGHORN_BACKEND_DEVICE
+          value: ""  # the backend device of Longhorn volume
         - name: FILE_NAME
           value: "/volume/test"
         - name: SIZE
@@ -42,6 +44,8 @@ spec:
         #volumeDevices:
         #- name: vol
         #  devicePath: /volume/test
+        securityContext:
+          privileged: true
       restartPolicy: Never
       volumes:
       - name: vol

--- a/fio/cmp_parse.sh
+++ b/fio/cmp_parse.sh
@@ -15,13 +15,13 @@ if [ -z "SECOND_VOL_NAME" ]; then
 	exit 1
 fi
 
-FIRST_IOPS=${FIRST_VOL_NAME}-iops.json
-FIRST_BW=${FIRST_VOL_NAME}-bandwidth.json
-FIRST_LAT=${FIRST_VOL_NAME}-latency.json
+FIRST_IOPS=/output/${FIRST_VOL_NAME}-iops.json
+FIRST_BW=/output/${FIRST_VOL_NAME}-bandwidth.json
+FIRST_LAT=/output/${FIRST_VOL_NAME}-latency.json
 
-SECOND_IOPS=${SECOND_VOL_NAME}-iops.json
-SECOND_BW=${SECOND_VOL_NAME}-bandwidth.json
-SECOND_LAT=${SECOND_VOL_NAME}-latency.json
+SECOND_IOPS=/output/${SECOND_VOL_NAME}-iops.json
+SECOND_BW=/output/${SECOND_VOL_NAME}-bandwidth.json
+SECOND_LAT=/output/${SECOND_VOL_NAME}-latency.json
 
 parse_iops $FIRST_IOPS
 FIRST_RAND_READ_IOPS=$RAND_READ_IOPS
@@ -71,7 +71,7 @@ SECOND_CPU_IDLE_PCT_LAT=$CPU_IDLE_PCT_LAT
 
 calc_cmp_lat
 
-RESULT=${FIRST_VOL_NAME}_vs_${SECOND_VOL_NAME}.summary
+RESULT=/output/${FIRST_VOL_NAME}_vs_${SECOND_VOL_NAME}.summary
 
 QUICK_MODE_TEXT="Quick Mode: disabled"
 if [ -n "$QUICK_MODE" ]; then

--- a/fio/cmp_run.sh
+++ b/fio/cmp_run.sh
@@ -25,10 +25,14 @@ if [ -z "SECOND_VOL_FILE" ]; then
 	exit 1
 fi
 
+# clean up the previous result
+rm -rf /output/*
+
 #disable parsing in run.sh
 export SKIP_PARSE=1
 
-$CURRENT_DIR/run.sh $FIRST_VOL_FILE $FIRST_VOL_NAME
-$CURRENT_DIR/run.sh $SECOND_VOL_FILE $SECOND_VOL_NAME
+# already cleanup, skip it in run.sh
+SKIP_CLEANUP=1 $CURRENT_DIR/run.sh $FIRST_VOL_FILE $FIRST_VOL_NAME $FIRST_VOL_BACKEND_DEVICE
+SKIP_CLEANUP=1 $CURRENT_DIR/run.sh $SECOND_VOL_FILE $SECOND_VOL_NAME $SECOND_VOL_BACKEND_DEVICE
 
 $CURRENT_DIR/cmp_parse.sh

--- a/fio/parse.sh
+++ b/fio/parse.sh
@@ -12,9 +12,9 @@ then
 fi
 
 PREFIX=${1}
-OUTPUT_IOPS=${PREFIX}-iops.json
-OUTPUT_BW=${PREFIX}-bandwidth.json
-OUTPUT_LAT=${PREFIX}-latency.json
+OUTPUT_IOPS=/output/${PREFIX}-iops.json
+OUTPUT_BW=/output/${PREFIX}-bandwidth.json
+OUTPUT_LAT=/output/${PREFIX}-latency.json
 
 if [ ! -f "$OUTPUT_IOPS" ]; then
         echo "$OUTPUT_IOPS doesn't exist"
@@ -34,7 +34,7 @@ else
         parse_lat $OUTPUT_LAT
 fi
 
-RESULT=${1}.summary
+RESULT=/output/${1}.summary
 
 QUICK_MODE_TEXT="Quick Mode: disabled"
 if [ -n "$QUICK_MODE" ]; then


### PR DESCRIPTION
  - that we can do more investigation with these output files

For example, we will get the output like the following.
```
harvester-node-2:~ # ls output/
Local-Path-bandwidth-iostat.log  Local-Path-iops.json           Local-Path_vs_Longhorn.summary  Longhorn-iops-iostat.log     Longhorn-latency.json
Local-Path-bandwidth.json        Local-Path-latency-iostat.log  Longhorn-bandwidth-iostat.log   Longhorn-iops.json
Local-Path-iops-iostat.log       Local-Path-latency.json        Longhorn-bandwidth.json         Longhorn-latency-iostat.log
```

We could compare iostat data between Local-Path and Longhorn for further investigation.
 