### PR TITLE
Modify fio job files to use ConfigMap

### DIFF
--- a/deploy/fio-custom.yaml
+++ b/deploy/fio-custom.yaml
@@ -89,57 +89,57 @@ data:
   bandwidth-quick.fio: |
     [rand-read-bw]
     readwrite=randread
-    include bw-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [rand-write-bw]
     readwrite=randwrite
-    include bw-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [seq-read-bw]
     readwrite=read
-    include bw-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [seq-write-bw]
     readwrite=write
-    include bw-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/quick-include.fio
   bandwidth-random-read.fio: |
     [rand-read-bw]
     readwrite=randread
-    include bw-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/common-include.fio
   bandwidth-random-write.fio: |
     [rand-write-bw]
     readwrite=randwrite
-    include bw-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/common-include.fio
   bandwidth-sequential-read.fio: |
     [seq-read-bw]
     readwrite=read
-    include bw-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/common-include.fio
   bandwidth-sequential-write.fio: |
     [seq-write-bw]
     readwrite=write
-    include bw-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/common-include.fio
   bandwidth.fio: |
     [rand-read-bw]
     readwrite=randread
-    include bw-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [rand-write-bw]
     readwrite=randwrite
-    include bw-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [seq-read-bw]
     readwrite=read
-    include bw-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [seq-write-bw]
     readwrite=write
-    include bw-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/bw-include.fio
+    include /etc/fio-custom-config/common-include.fio
   bw-include.fio: |
     bs=128k
     iodepth=64
@@ -158,114 +158,114 @@ data:
   iops-quick.fio: |
     [rand-read-iops]
     readwrite=randread
-    include iops-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [rand-write-iops]
     readwrite=randwrite
-    include iops-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [seq-read-iops]
     readwrite=read
-    include iops-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [seq-write-iops]
     readwrite=write
-    include iops-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/quick-include.fio
   iops-random-read.fio: |
     [rand-read-iops]
     readwrite=randread
-    include iops-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/common-include.fio
   iops-random-write.fio: |
     [rand-write-iops]
     readwrite=randwrite
-    include iops-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/common-include.fio
   iops-sequential-read.fio: |
     [seq-read-iops]
     readwrite=read
-    include iops-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/common-include.fio
   iops-sequential-write.fio: |
     [seq-write-iops]
     readwrite=write
-    include iops-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/common-include.fio
   iops.fio: |
     [rand-read-iops]
     readwrite=randread
-    include iops-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [rand-write-iops]
     readwrite=randwrite
-    include iops-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [seq-read-iops]
     readwrite=read
-    include iops-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [seq-write-iops]
     readwrite=write
-    include iops-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/iops-include.fio
+    include /etc/fio-custom-config/common-include.fio
   lat-include.fio: |
     bs=4k
     iodepth=1
   latency-quick.fio: |
     [rand-read-lat]
     readwrite=randread
-    include lat-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [rand-write-lat]
     readwrite=randwrite
-    include lat-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [seq-read-lat]
     readwrite=read
-    include lat-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/quick-include.fio
     [seq-write-lat]
     readwrite=write
-    include lat-include.fio
-    include quick-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/quick-include.fio
   latency-random-read.fio: |
     [rand-read-lat]
     readwrite=randread
-    include lat-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/common-include.fio
   latency-random-write.fio: |
     [rand-write-lat]
     readwrite=randwrite
-    include lat-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/common-include.fio
   latency-sequential-read.fio: |
     [seq-read-lat]
     readwrite=read
-    include lat-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/common-include.fio
   latency-sequential-write.fio: |
     [seq-write-lat]
     readwrite=write
-    include lat-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/common-include.fio
   latency.fio: |
     [rand-read-lat]
     readwrite=randread
-    include lat-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [rand-write-lat]
     readwrite=randwrite
-    include lat-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [seq-read-lat]
     readwrite=read
-    include lat-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/common-include.fio
     [seq-write-lat]
     readwrite=write
-    include lat-include.fio
-    include common-include.fio
+    include /etc/fio-custom-config/lat-include.fio
+    include /etc/fio-custom-config/common-include.fio
   quick-include.fio: |
     stonewall=1
     randrepeat=0

--- a/deploy/fio-custom.yaml
+++ b/deploy/fio-custom.yaml
@@ -1,0 +1,277 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: kbench-pvc
+spec:
+  volumeMode: Filesystem
+  #volumeMode: Block
+  #storageClassName: longhorn  # replace with your storage class
+  #storageClassName: local-path
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 33Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kbench
+spec:
+  template:
+    metadata:
+      labels:
+        kbench: fio
+    spec:
+      containers:
+      - name: kbench
+        image: yasker/kbench:latest
+        imagePullPolicy: Always
+        env:
+#        - name: MODE
+#          value: "quick" # for debugging
+#        - name: MODE
+#          value: "random-read-iops"
+#        - name: MODE
+#          value: "sequential-read-iops"
+#        - name: MODE
+#          value: "random-read-bandwidth"
+#        - name: MODE
+#          value: "sequential-read-bandwidth"
+#        - name: MODE
+#          value: "random-read-latency"
+#        - name: MODE
+#          value: "sequential-read-latency"
+#        - name: MODE
+#          value: "random-write-iops"
+#        - name: MODE
+#          value: "sequential-write-iops"
+#        - name: MODE
+#          value: "random-write-bandwidth"
+#        - name: MODE
+#          value: "sequential-write-bandwidth"
+#        - name: MODE
+#          value: "random-write-latency"
+#        - name: MODE
+#          value: "sequential-write-latency"
+        - name: MODE
+          value: "full" # run all tests
+        - name: FILE_NAME
+          value: "/volume/test"
+        - name: SIZE
+          value: "30G" # must be 10% smaller than the PVC size due to filesystem also took space
+        - name: CPU_IDLE_PROF
+          value: "disabled" # must be "enabled" or "disabled"
+        volumeMounts:
+        - name: vol
+          mountPath: /volume/
+        - name: fio-custom-config
+          mountPath: /etc/fio-custom-config
+        #volumeDevices:
+        #- name: vol
+        #  devicePath: /volume/test
+      restartPolicy: Never
+      volumes:
+      - name: vol
+        persistentVolumeClaim:
+          claimName: kbench-pvc
+      - name: fio-custom-config
+        configMap:
+          name: fio-custom-config
+  backoffLimit: 0
+---
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-custom-config
+data:
+  bandwidth-quick.fio: |
+    [rand-read-bw]
+    readwrite=randread
+    include bw-include.fio
+    include quick-include.fio
+    [rand-write-bw]
+    readwrite=randwrite
+    include bw-include.fio
+    include quick-include.fio
+    [seq-read-bw]
+    readwrite=read
+    include bw-include.fio
+    include quick-include.fio
+    [seq-write-bw]
+    readwrite=write
+    include bw-include.fio
+    include quick-include.fio
+  bandwidth-random-read.fio: |
+    [rand-read-bw]
+    readwrite=randread
+    include bw-include.fio
+    include common-include.fio
+  bandwidth-random-write.fio: |
+    [rand-write-bw]
+    readwrite=randwrite
+    include bw-include.fio
+    include common-include.fio
+  bandwidth-sequential-read.fio: |
+    [seq-read-bw]
+    readwrite=read
+    include bw-include.fio
+    include common-include.fio
+  bandwidth-sequential-write.fio: |
+    [seq-write-bw]
+    readwrite=write
+    include bw-include.fio
+    include common-include.fio
+  bandwidth.fio: |
+    [rand-read-bw]
+    readwrite=randread
+    include bw-include.fio
+    include common-include.fio
+    [rand-write-bw]
+    readwrite=randwrite
+    include bw-include.fio
+    include common-include.fio
+    [seq-read-bw]
+    readwrite=read
+    include bw-include.fio
+    include common-include.fio
+    [seq-write-bw]
+    readwrite=write
+    include bw-include.fio
+    include common-include.fio
+  bw-include.fio: |
+    bs=128k
+    iodepth=64
+  common-include.fio: |
+    stonewall=1
+    randrepeat=0
+    verify=0
+    ioengine=libaio
+    direct=1
+    time_based=1
+    ramp_time=5s
+    runtime=20s
+  iops-include.fio: |
+    bs=4K
+    iodepth=64
+  iops-quick.fio: |
+    [rand-read-iops]
+    readwrite=randread
+    include iops-include.fio
+    include quick-include.fio
+    [rand-write-iops]
+    readwrite=randwrite
+    include iops-include.fio
+    include quick-include.fio
+    [seq-read-iops]
+    readwrite=read
+    include iops-include.fio
+    include quick-include.fio
+    [seq-write-iops]
+    readwrite=write
+    include iops-include.fio
+    include quick-include.fio
+  iops-random-read.fio: |
+    [rand-read-iops]
+    readwrite=randread
+    include iops-include.fio
+    include common-include.fio
+  iops-random-write.fio: |
+    [rand-write-iops]
+    readwrite=randwrite
+    include iops-include.fio
+    include common-include.fio
+  iops-sequential-read.fio: |
+    [seq-read-iops]
+    readwrite=read
+    include iops-include.fio
+    include common-include.fio
+  iops-sequential-write.fio: |
+    [seq-write-iops]
+    readwrite=write
+    include iops-include.fio
+    include common-include.fio
+  iops.fio: |
+    [rand-read-iops]
+    readwrite=randread
+    include iops-include.fio
+    include common-include.fio
+    [rand-write-iops]
+    readwrite=randwrite
+    include iops-include.fio
+    include common-include.fio
+    [seq-read-iops]
+    readwrite=read
+    include iops-include.fio
+    include common-include.fio
+    [seq-write-iops]
+    readwrite=write
+    include iops-include.fio
+    include common-include.fio
+  lat-include.fio: |
+    bs=4k
+    iodepth=1
+  latency-quick.fio: |
+    [rand-read-lat]
+    readwrite=randread
+    include lat-include.fio
+    include quick-include.fio
+    [rand-write-lat]
+    readwrite=randwrite
+    include lat-include.fio
+    include quick-include.fio
+    [seq-read-lat]
+    readwrite=read
+    include lat-include.fio
+    include quick-include.fio
+    [seq-write-lat]
+    readwrite=write
+    include lat-include.fio
+    include quick-include.fio
+  latency-random-read.fio: |
+    [rand-read-lat]
+    readwrite=randread
+    include lat-include.fio
+    include common-include.fio
+  latency-random-write.fio: |
+    [rand-write-lat]
+    readwrite=randwrite
+    include lat-include.fio
+    include common-include.fio
+  latency-sequential-read.fio: |
+    [seq-read-lat]
+    readwrite=read
+    include lat-include.fio
+    include common-include.fio
+  latency-sequential-write.fio: |
+    [seq-write-lat]
+    readwrite=write
+    include lat-include.fio
+    include common-include.fio
+  latency.fio: |
+    [rand-read-lat]
+    readwrite=randread
+    include lat-include.fio
+    include common-include.fio
+    [rand-write-lat]
+    readwrite=randwrite
+    include lat-include.fio
+    include common-include.fio
+    [seq-read-lat]
+    readwrite=read
+    include lat-include.fio
+    include common-include.fio
+    [seq-write-lat]
+    readwrite=write
+    include lat-include.fio
+    include common-include.fio
+  quick-include.fio: |
+    stonewall=1
+    randrepeat=0
+    verify=0
+    ioengine=libaio
+    direct=1
+    time_based=1
+    ramp_time=1s
+    runtime=5s

--- a/fio/run.sh
+++ b/fio/run.sh
@@ -3,6 +3,14 @@
 set -e
 
 CURRENT_DIR="$(dirname "$(readlink -f "$0")")"
+CONFIG_DIR="/etc/fio-custom-config"
+
+if [ -d "$CONFIG_DIR" ]; then
+    echo "Use fio custom config in: $CONFIG_DIR"
+else
+    CONFIG_DIR="$CURRENT_DIR"
+    echo "No custom config found, CONFIG_DIR is now set to default: $CONFIG_DIR"
+fi
 
 TEST_FILE=$1
 
@@ -150,19 +158,19 @@ keep_running="true"
 while [ "$keep_running" == "true" ]; do
     if [ -n "$IOPS_FIO" ]; then
         echo Benchmarking $IOPS_FIO into $OUTPUT_IOPS
-        fio $CURRENT_DIR/$IOPS_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
+        fio $CONFIG_DIR/$IOPS_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
           --output-format=json --output=$TEMP $rate_iops_flag $rate_flag
         mv $TEMP $OUTPUT_IOPS
     fi
     if [ -n "$BW_FIO" ]; then
         echo Benchmarking $BW_FIO into $OUTPUT_BW
-        fio $CURRENT_DIR/$BW_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
+        fio $CONFIG_DIR/$BW_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
           --output-format=json --output=$TEMP $rate_iops_flag $rate_flag
         mv $TEMP $OUTPUT_BW
     fi
     if [ -n "$LAT_FIO" ]; then
         echo Benchmarking $LAT_FIO into $OUTPUT_LAT
-        fio $CURRENT_DIR/$LAT_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
+        fio $CONFIG_DIR/$LAT_FIO $IDLE_PROF --filename=$TEST_FILE --size=$TEST_SIZE \
           --output-format=json --output=$TEMP $rate_iops_flag $rate_flag
         mv $TEMP $OUTPUT_LAT
     fi


### PR DESCRIPTION
I’ve implemented the idea discussed in the issue. This PR depends on the previous https://github.com/longhorn/kbench/pull/9, so I will make further changes after that PR is merged.

If we use *.fio files in a ConfigMap:

### Cons:

* Requires two apply commands to run the workload:
```
k apply -f fio-config.yaml
k apply -f fio.yaml
```

### Pros:
* Easier to modify workloads through the ConfigMap.

Please review and provide feedback on these points. @derekbit 


related: https://github.com/longhorn/longhorn/issues/9100