### PR TITLE
Run without privilaged rights

### DIFF
--- a/deploy/fio-cmp.yaml
+++ b/deploy/fio-cmp.yaml
@@ -88,6 +88,8 @@ spec:
           mountPath: /volume1/
         - name: vol2
           mountPath: /volume2/
+        - mountPath: /temp
+          name: temp-storage
         command: ["bash", "/fio/cmp_run.sh"]
         #volumeDevices:
         #- name: vol1
@@ -102,4 +104,6 @@ spec:
       - name: vol2
         persistentVolumeClaim:
           claimName: kbench-pvc-2
+      - name: temp-storage
+        emptyDir: {}
   backoffLimit: 0

--- a/deploy/fio-long-run.yaml
+++ b/deploy/fio-long-run.yaml
@@ -89,8 +89,12 @@ spec:
               mountPath: /volume/
             - name: shared-data
               mountPath: /test-result
+            - mountPath: /temp
+              name: temp-storage
       volumes:
         - name: shared-data
+          emptyDir: {}
+        - name: temp-storage
           emptyDir: {}
   volumeClaimTemplates:
     - metadata:

--- a/deploy/fio.yaml
+++ b/deploy/fio.yaml
@@ -65,6 +65,8 @@ spec:
         volumeMounts:
         - name: vol
           mountPath: /volume/
+        - mountPath: /temp
+          name: temp-storage
         #volumeDevices:
         #- name: vol
         #  devicePath: /volume/test
@@ -73,4 +75,6 @@ spec:
       - name: vol
         persistentVolumeClaim:
           claimName: kbench-pvc
+      - name: temp-storage
+        emptyDir: {}
   backoffLimit: 0

--- a/fio/run.sh
+++ b/fio/run.sh
@@ -5,6 +5,7 @@ set -e
 CURRENT_DIR="$(dirname "$(readlink -f "$0")")"
 
 TEST_FILE=$1
+cd /temp
 
 # cmdline overrides the environment variable
 if [ -z "$TEST_FILE" ]; then
@@ -141,7 +142,7 @@ else
 fi
 
 
-TEMP=./temp
+TEMP=/temp/tmpfile
 OUTPUT_IOPS=${TEST_OUTPUT}-iops.json
 OUTPUT_BW=${TEST_OUTPUT}-bandwidth.json
 OUTPUT_LAT=${TEST_OUTPUT}-latency.json


### PR DESCRIPTION
Added a Volume for  /temp, which is now in use for temporary files.
So we can run all jobs without root-rights, because we need no privileged access to the local host filesystem.